### PR TITLE
Fix regex pattern for secret input validation in CreateGroupView comp…

### DIFF
--- a/src/views/CreateGroupView.vue
+++ b/src/views/CreateGroupView.vue
@@ -35,7 +35,7 @@
       <BFormGroup v-if="type === GroupType.Private" id="secret-group" label="Secret:" label-for="secret"
         description="A 6-digit secret required to join this private group." class="mb-3">
         <BFormInput id="secret" v-model="secret" type="text" :state="secretState" placeholder="Enter 6-digit secret"
-          pattern="\\d{6}" maxlength="6"></BFormInput>
+          pattern="\d{6}" maxlength="6"></BFormInput>
         <BFormInvalidFeedback :state="secretState">
           Secret must be exactly 6 digits.
         </BFormInvalidFeedback>


### PR DESCRIPTION
### **User description**
Fix regex pattern for secret input validation in CreateGroupView component.


___

### **PR Type**
Bug fix. Fixes #1 


___

### **Description**
- Corrects the regex pattern for secret input validation.

- Ensures 6-digit secret validation works as intended.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CreateGroupView.vue</strong><dd><code>Correct regex for 6-digit secret input validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/views/CreateGroupView.vue

<li>Fixed the regex pattern for the secret input field.<br> <li> Changed pattern from '\\d{6}' to '\d{6}' for proper validation.


</details>


  </td>
  <td><a href="https://github.com/championswimmer/app.midpoint.place/pull/2/files#diff-5b22e2a4f31cd197dd50dcdd15cef822d3fe40b184663d6333f536149a0fc17f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>